### PR TITLE
Detect duplicate phenotype search hits. For example, user could searc…

### DIFF
--- a/client/app/models/GeneModel.js
+++ b/client/app/models/GeneModel.js
@@ -224,7 +224,12 @@ class GeneModel {
           ranks = [];
           searchTerms[searchTerm] = ranks;
         }
-        ranks.push( {'rank': phenotypeGene.rank, 'source': 'Phenolyzer'});
+        let matchingRanks = ranks.filter(function(entry) {
+          return entry.source == 'Phenolyzer' && entry.rank == phenotypeGene.rank;
+        })
+        if (matchingRanks.length == 0) {
+          ranks.push( {'rank': phenotypeGene.rank, 'source': 'Phenolyzer'});
+        }
       })
     }
 


### PR DESCRIPTION
…h on 'Charcot Marie Tooth', setting the max genes to 20 and then increasing the max genes to 50 and searching on the same term again.