### PR TITLE
Pass selectedTranscript to Viz #983

### DIFF
--- a/client/app/components/partials/TranscriptsMenu.vue
+++ b/client/app/components/partials/TranscriptsMenu.vue
@@ -142,6 +142,7 @@
                           :regionEnd="selectedGene.end"
                           :showBrush=false
                           :showXAxis=false
+                          :selectedTranscript="selectedTranscript"
                           @transcript-selected="onTranscriptSelected">
                 </gene-viz>
 

--- a/client/app/components/viz/GeneViz.vue
+++ b/client/app/components/viz/GeneViz.vue
@@ -151,6 +151,10 @@
                 default: 0,
                 type: Number
             },
+            selectedTranscript: {
+                default: null,
+                type: Object
+            },
             relationship: null,
 
             regionEnd: {
@@ -267,10 +271,20 @@
                     if(this.isStandalone){
                         return "transcript";
                     }
-                    if (d.isCanonical) {
-                        return 'transcript current';
+                    // If no transcript is selected, then the canonical transcript is the current transcript
+                    if (!this.selectedTranscript){
+                        if (d.isCanonical) {
+                            return 'transcript current';
+                        } else {
+                            return 'transcript';
+                        }
+                    // If a transcript is selected, then the selected transcript is the current transcript
                     } else {
-                        return 'transcript';
+                        if (d.transcript_id == this.selectedTranscript.transcript_id) {
+                            return 'transcript current';
+                        } else {
+                            return 'transcript';
+                        }
                     }
             },
 


### PR DESCRIPTION
Passed the "selectedTranscript" to the viz so that we can conditionally render the classes based on if there is a selected transcript or not if not select MANE.

It seems that 'transcriptSelected' is emitted up the tree `transcriptsMenu->transcriptCart->geneHome` where it is used to then update the state of other components. Something about this causes the geneViz to re-render and call that 'transcriptClass' function that we looked at.

Passing the selectedTranscript an additional level down to the geneViz & adding some conditional logic in that function that uses the selectedTranscript if it is present seems to get this working like we would expect.