### PR TITLE
Em #899

### DIFF
--- a/client/app/components/partials/FilterSettings.vue
+++ b/client/app/components/partials/FilterSettings.vue
@@ -171,7 +171,7 @@
 
       <v-flex xs12 style="margin-top:10px;margin-bottom: 5px"  >
         <v-flex id="max-homozygotes"   >
-          <v-text-field style="display:inline-block" label="Max Population Homozygotes" :rules="wholeNumRules" v-model="maxHomozygotes" hide-details>
+          <v-text-field style="display:inline-block" label="Max Number of Homozygotes" :rules="wholeNumRules" v-model="maxHomozygotes" hide-details>
           </v-text-field>
         </v-flex>
       </v-flex>

--- a/client/app/components/partials/FilterSettings.vue
+++ b/client/app/components/partials/FilterSettings.vue
@@ -58,6 +58,10 @@
     .v-input.v-text-field 
       min-width: 200px
 
+  #max-homozygotes
+    .v-input.v-text-field 
+      min-width: 200px
+
   .input-group
     label
       font-style: italic !important
@@ -163,6 +167,13 @@
             To speed up filtering, the gnomAD <span style='font-style: italic; font-weight:bold'> exomes only </span> pop max allele frequency is used. Allele frequencies from gnomAD exomes are less complete, so variants may pass this filter and have a higher allele frequency in gnomAD genomes. (After clicking on a variant, the allele frequency from gnomAD genomes will be shown.)
         </div>
 
+      </v-flex>
+
+      <v-flex xs12 style="margin-top:10px;margin-bottom: 5px"  >
+        <v-flex id="max-homozygotes"   >
+          <v-text-field style="display:inline-block" label="Max Homozygotes" :rules="wholeNumRules" v-model="maxHomozygotes" hide-details>
+          </v-text-field>
+        </v-flex>
       </v-flex>
 
       <v-flex xs12  >
@@ -279,6 +290,7 @@ export default {
       isDirty: false,
       name: null,
       maxAf: null,
+      maxHomozygotes: null,
       minRevel: null,
       selectedClinvarCategories: null,
       selectedImpacts: null,
@@ -351,6 +363,12 @@ export default {
           return valid || 'Freq must be between 0.0-1.0';
         }
       ],
+      wholeNumRules: [
+        v => {
+          let valid = v ? (+v > 0) : true;
+          return valid || 'Must be a whole number';
+        }
+      ],
       rules: {
           noDuplicates: value => !this.isDuplicateName() || 'Another filter already has this name. Please enter a filter name not already in use.'
       }
@@ -369,6 +387,7 @@ export default {
         flagCriteria.active = false;
         flagCriteria.name = this.filter.display;
         flagCriteria.maxAf = null;
+        flagCriteria.maxHomozygotes = null;
         flagCriteria.minRevel = null;
         flagCriteria.clinvar = null;
         flagCriteria.impact = null;
@@ -381,6 +400,7 @@ export default {
       this.name                      = flagCriteria.name;
       this.key                       = flagCriteria.key + flagCriteria.name;
       this.maxAf                     = flagCriteria.maxAf;
+      this.maxHomozygotes            = flagCriteria.maxHomozygotes;
       this.minRevel                  = flagCriteria.minRevel;
       this.selectedClinvarCategories = flagCriteria.clinvar;
       this.selectedImpacts           = flagCriteria.impact;
@@ -411,6 +431,7 @@ export default {
 
       flagCriteria.key = this.key;
       flagCriteria.maxAf            = this.maxAf;
+      flagCriteria.maxHomozygotes   = this.maxHomozygotes;
       flagCriteria.minRevel         = this.minRevel;
       flagCriteria.clinvar =          this.selectedClinvarCategories;
       flagCriteria.impact           = this.selectedImpacts;
@@ -461,6 +482,7 @@ export default {
       return (!this.isDuplicateName()) &&
              (
                (this.maxAf && this.maxAf > 0 && this.maxAf < 1) ||
+               (this.maxHomozygotes && this.maxHomozygotes > 0) ||
                this.minRevel ||
                (this.selectedClinvarCategories && this.selectedClinvarCategories.length > 0) ||
                (this.selectedImpacts && this.selectedImpacts.length > 0) ||
@@ -487,6 +509,9 @@ export default {
   watch: {
 
     maxAf: function() {
+      this.isDirty = true;
+    },
+    maxHomozygotes: function() {
       this.isDirty = true;
     },
     selectedClinvarCategories: function() {

--- a/client/app/components/partials/FilterSettings.vue
+++ b/client/app/components/partials/FilterSettings.vue
@@ -56,11 +56,11 @@
 
   #max-af
     .v-input.v-text-field 
-      min-width: 200px
+      min-width: 220px
 
   #max-homozygotes
     .v-input.v-text-field 
-      min-width: 200px
+      min-width: 220px
 
   .input-group
     label
@@ -171,7 +171,7 @@
 
       <v-flex xs12 style="margin-top:10px;margin-bottom: 5px"  >
         <v-flex id="max-homozygotes"   >
-          <v-text-field style="display:inline-block" label="Max Homozygotes" :rules="wholeNumRules" v-model="maxHomozygotes" hide-details>
+          <v-text-field style="display:inline-block" label="Max Population Homozygotes" :rules="wholeNumRules" v-model="maxHomozygotes" hide-details>
           </v-text-field>
         </v-flex>
       </v-flex>

--- a/client/app/components/partials/FilterSettings.vue
+++ b/client/app/components/partials/FilterSettings.vue
@@ -365,7 +365,7 @@ export default {
       ],
       wholeNumRules: [
         v => {
-          let valid = v ? (+v > 0) : true;
+          let valid = v ? (+v >= 0) : true;
           return valid || 'Must be a whole number';
         }
       ],
@@ -482,7 +482,7 @@ export default {
       return (!this.isDuplicateName()) &&
              (
                (this.maxAf && this.maxAf > 0 && this.maxAf < 1) ||
-               (this.maxHomozygotes && this.maxHomozygotes > 0) ||
+               (this.maxHomozygotes && this.maxHomozygotes >= 0) ||
                this.minRevel ||
                (this.selectedClinvarCategories && this.selectedClinvarCategories.length > 0) ||
                (this.selectedImpacts && this.selectedImpacts.length > 0) ||

--- a/client/app/components/viz/FlaggedVariantsCard.vue
+++ b/client/app/components/viz/FlaggedVariantsCard.vue
@@ -1500,6 +1500,7 @@ export default {
       flagCriteria.active = false;
       flagCriteria.name = newFilter.name;
       flagCriteria.maxAf = null;
+      flagCriteria.maxHomozygotes = null;
       flagCriteria.minRevel = null;
       flagCriteria.clinvar = null;
       flagCriteria.impact = null;

--- a/client/app/components/viz/VariantInspectCard.vue
+++ b/client/app/components/viz/VariantInspectCard.vue
@@ -783,10 +783,10 @@
           </variant-inspect-row>
           <variant-inspect-row v-if="!isSimpleMode && afGnomAD.freqPopMax" :clazz="afGnomAD.class" :value="gnomadFreqPopMax" :label="`Population max allele frequency`" >
           </variant-inspect-row>
-          <div v-if="!isSimpleMode && afGnomAD.totalCount > 0" class="variant-row no-icon">
+          <div v-if="!isSimpleMode && afGnomAD.totalCount >= 0" class="variant-row no-icon">
             <span>{{ afGnomAD.altCount }} alt of {{ afGnomAD.totalCount }} total</span>
           </div>
-          <div v-if="!isSimpleMode && afGnomAD.homCount > 0"  class="variant-row no-icon">
+          <div v-if="!isSimpleMode && afGnomAD.homCount >= 0"  class="variant-row no-icon">
             <span>{{ afGnomAD.homCount }} homozygotes</span>
           </div>
 
@@ -1977,13 +1977,39 @@ export default {
           }
 
           if (this.selectedVariant.gnomAD == null || this.selectedVariant.gnomAD.af == null) {
-            return {freq: "?", link: null, class: "", source: source,
-                    infoPopup: infoPopup, extraInfo1: extraInfo1, extraInfo2: extraInfo2,
-                    afExomes: afExomes};
+            return {
+              link: null,
+              label: "Allele frequency",
+              freq: "?", 
+              class: "",
+              freqPopMax: '0',
+              altCount: '0', 
+              totalCount: '0',
+              homCount: '0',
+              source: source,
+              loading: null,
+              infoPopup: infoPopup, 
+              extraInfo1: extraInfo1, 
+              extraInfo2: extraInfo2,
+              afExomes: afExomes
+            };
           } else if (this.selectedVariant.gnomAD.af  == '.') {
-            return {freq: "0", link: null, class: "level-high", source: source,
-                    infoPopup: infoPopup, extraInfo1: extraInfo1, extraInfo2: extraInfo2,
-                    afExomes: afExomes};
+            return {
+              link: null,
+              label: "Allele frequency",
+              freq: '0',  
+              class: "level-high",
+              freqPopMax: '0',
+              altCount: '0', 
+              totalCount: '0',
+              homCount: '0',
+              source: source,
+              loading: null,
+              infoPopup: infoPopup, 
+              extraInfo1: extraInfo1, 
+              extraInfo2: extraInfo2,
+              afExomes: afExomes
+            };
           } else  {
             var gnomAD = {};
             gnomAD.link =  "http://gnomad.broadinstitute.org/variant/"

--- a/client/app/models/FilterModel.js
+++ b/client/app/models/FilterModel.js
@@ -49,6 +49,7 @@ class FilterModel {
           order: 0,
           userFlagged: false,
           maxAf: null,
+          maxHomozygotes: null,
           clinvar: null,
           impact: null,
           consequence: null,
@@ -67,6 +68,7 @@ class FilterModel {
           order: 1,
           userFlagged: false,
           maxAf: .05,
+          maxHomozygotes: null,
           clinvar: ['clinvar_path', 'clinvar_lpath'],
           impact: null,
           consequence: null,
@@ -85,6 +87,7 @@ class FilterModel {
           order: 2,
           userFlagged: false,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -103,6 +106,7 @@ class FilterModel {
           order: 3,
           userFlagged: false,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -122,6 +126,7 @@ class FilterModel {
           order: 4,
           userFlagged: false,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -140,6 +145,7 @@ class FilterModel {
           order: 5,
           userFlagged: false,
           maxAf: .05,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -158,6 +164,7 @@ class FilterModel {
           userFlagged: false,
           order: 6,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -176,6 +183,7 @@ class FilterModel {
           order: 7,
           userFlagged: false,
           maxAf: .025,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -214,6 +222,7 @@ class FilterModel {
           order: 8,
           userFlagged: false,
           maxAf: null,
+          maxHomozygotes: null,
           clinvar: null,
           impact: null,
           consequence: null,
@@ -233,6 +242,7 @@ class FilterModel {
           order: 9,
           userFlagged: false,
           maxAf: null,
+          maxHomozygotes: null,
           clinvar: null,
           impact: null,
           consequence: null,
@@ -255,6 +265,7 @@ class FilterModel {
           order: 0,
           userFlagged: false,
           maxAf: null,
+          maxHomozygotes: null,
           clinvar: null,
           impact: null,
           consequence: null,
@@ -273,6 +284,7 @@ class FilterModel {
           order: 1,
           userFlagged: false,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: ['clinvar_path', 'clinvar_lpath'],
           impact: null,
           consequence: null,
@@ -291,6 +303,7 @@ class FilterModel {
           order: 2,
           userFlagged: false,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -309,6 +322,7 @@ class FilterModel {
           order: 3,
           userFlagged: false,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -328,6 +342,7 @@ class FilterModel {
           order: 4,
           userFlagged: false,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -346,6 +361,7 @@ class FilterModel {
           order: 5,
           userFlagged: false,
           maxAf: .05,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -364,6 +380,7 @@ class FilterModel {
           userFlagged: false,
           order: 6,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', 'MODERATE'],
           consequence: null,
@@ -382,6 +399,7 @@ class FilterModel {
           order: 7,
           userFlagged: false,
           maxAf: .01,
+          maxHomozygotes: null,
           clinvar: null,
           impact: ['HIGH', ],
           consequence: null,
@@ -402,6 +420,7 @@ class FilterModel {
           order: 8,
           userFlagged: false,
           maxAf: null,
+          maxHomozygotes: null,
           clinvar: null,
           impact: null,
           consequence: null,
@@ -421,6 +440,7 @@ class FilterModel {
           order: 9,
           userFlagged: false,
           maxAf: null,
+          maxHomozygotes: null,
           clinvar: null,
           impact: null,
           consequence: null,
@@ -951,6 +971,7 @@ class FilterModel {
     var passes = {
       all: false,
       af: false,
+      homozygotes: false,
       impact: false,
       consequence: false,
       clinvar: false,
@@ -982,6 +1003,9 @@ class FilterModel {
     } else {
       if (badgeCriteria.maxAf == null || (variant.afHighest <= badgeCriteria.maxAf)) {
         passes.af = true;
+      }
+      if (badgeCriteria.maxHomozygotes == null || (parseInt(variant.gnomAD.homCount) <= parseInt(badgeCriteria.maxHomozygotes))) {
+        passes.homozygotes = true;
       }
       if (badgeCriteria.minRevel == null || badgeCriteria.minRevel == "") {
         passes.revel = true;
@@ -1037,7 +1061,7 @@ class FilterModel {
           passes[criterion] = true;
         })
       }
-      if (passes.af && passes.revel && passes.depth && passes.altCount && passes.impact && passes.consequence && passes.clinvar && passes.inheritance && passes.zygosity) {
+      if (passes.homozygotes && passes.af && passes.revel && passes.depth && passes.altCount && passes.impact && passes.consequence && passes.clinvar && passes.inheritance && passes.zygosity) {
         passes.all = true;
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gene-iobio-vue",
-  "version": "4.8",
+  "version": "4.8.0",
   "scripts": {
     "start": "DEBUG=http ./node_modules/nodemon/bin/nodemon.js --inspect --ignore client/ www.js",
     "build": "./node_modules/webpack/bin/webpack.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gene-iobio-vue",
-  "version": "4.8.0",
+  "version": "4.8",
   "scripts": {
     "start": "DEBUG=http ./node_modules/nodemon/bin/nodemon.js --inspect --ignore client/ www.js",
     "build": "./node_modules/webpack/bin/webpack.js",


### PR DESCRIPTION
Address issue #899 
Change allows users to create a custom filter using "max population homozygotes".

Also updated the data flow for the population area of the variant inspect card. Added fields to two of the logic branches so that the fields available from the "return" on each were uniform with other logic branches. Also will now render to the UI components even if the value displayed will be 0, for clarity.

Committed and **_reverted_** the patch level of the version just for build purposes. I can't build 4.9 without a 4.8.**_x_** in the package.json.

