### PR TITLE
Fixed cancel button behavior#1027

### DIFF
--- a/client/app/components/partials/SelectVariantAnnotationsDialog.vue
+++ b/client/app/components/partials/SelectVariantAnnotationsDialog.vue
@@ -217,10 +217,10 @@
       },
 
       cancelAnnotations() {
-        this.selectedInfo = [];
-        this.selectedFormat = [];
-        this.selectedMosaicVariantAnnotations = [];
-        this.selectedAll = false;
+        this.selectedInfo = this.selectedVariantInfo;
+        this.selectedFormat = this.selectedVariantFormat;
+        this.selectedMosaicVariantAnnotations = this.selectedVariantMosaic;
+        this.selectedAll = this.selectedVariantAllAnnots;
         this.$emit('close-variant-annot-dialog', this.selectedInfo, this.selectedFormat, this.selectedMosaicVariantAnnotations, this.selectedAll);
       },
 


### PR DESCRIPTION
Changed the behavior of 'cancel button' to get back the state since user pulled up the dialog.